### PR TITLE
Add portfolio single page layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,10 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Portfolio of Daniel Tibbotts">
+  <meta name="title" content="Daniel Tibbotts - Portfolio">
+  <meta name="description" content="Portfolio of software engineer Daniel Tibbotts">
   <title>Daniel Tibbotts - Portfolio</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -24,6 +26,8 @@
     </div>
   </header>
 
+  <main>
+
   <section class="hero">
     <div class="container hero-content">
       <img src="assets/images/me-AI.png" alt="Daniel Tibbotts">
@@ -35,6 +39,47 @@
     </div>
   </section>
 
+  <section class="testimonials fade-in">
+    <div class="container">
+      <h2>Testimonials</h2>
+      <div class="testimonial-grid">
+        <div class="testimonial-card">
+          <p>"Daniel delivered excellent work on time and exceeded our expectations."</p>
+          <span>- Client A</span>
+        </div>
+        <div class="testimonial-card">
+          <p>"Professional, reliable, and highly skilled."</p>
+          <span>- Client B</span>
+        </div>
+        <div class="testimonial-card">
+          <p>"Great communication and attention to detail throughout the project."</p>
+          <span>- Client C</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="cta fade-in">
+    <div class="container">
+      <h2>Ready to start a project?</h2>
+      <p>Let's build something great together.</p>
+      <a href="#contact" class="btn cta-btn">Get in Touch</a>
+    </div>
+  </section>
+
+
+
+
+
+  <section id="why" class="why fade-in">
+    <div class="container">
+      <h2>Why I Do It</h2>
+      <p>I am passionate about using technology to solve real problems and make life easier.</p>
+      <p>Building intuitive software allows me to learn continuously and help others succeed.</p>
+      <blockquote>"Whatever you do, work heartily, as for the Lord and not for men." - Colossians 3:23</blockquote>
+    </div>
+  </section>
+
   <section id="about" class="about">
     <div class="container">
       <h2>About Me</h2>
@@ -42,14 +87,56 @@
     </div>
   </section>
 
-  <section id="projects" class="projects">
+  <section id="projects" class="projects fade-in">
     <div class="container">
-      <h2>Featured Projects</h2>
-      <div class="project-grid">
-        <div class="project-item">Project One</div>
-        <div class="project-item">Project Two</div>
-        <div class="project-item">Project Three</div>
+      <h2>Portfolio</h2>
+      <div class="filter-bar">
+        <button class="filter-btn active" data-filter="all">All</button>
+        <button class="filter-btn" data-filter="web">Web</button>
+        <button class="filter-btn" data-filter="mobile">Mobile</button>
       </div>
+      <div class="project-grid">
+        <div class="project-item" data-category="web" data-description="Web project">
+          <img src="assets/images/me-AI.png" alt="Project One" loading="lazy">
+          <div class="overlay"><h3>Project One</h3></div>
+        </div>
+        <div class="project-item" data-category="mobile" data-description="Mobile project">
+          <img src="assets/images/me-AI.png" alt="Project Two" loading="lazy">
+          <div class="overlay"><h3>Project Two</h3></div>
+        </div>
+        <div class="project-item" data-category="web" data-description="Another web project">
+          <img src="assets/images/me-AI.png" alt="Project Three" loading="lazy">
+          <div class="overlay"><h3>Project Three</h3></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="testimonials fade-in">
+    <div class="container">
+      <h2>Testimonials</h2>
+      <div class="testimonial-grid">
+        <div class="testimonial-card">
+          <p>"Daniel delivered excellent work on time and exceeded our expectations."</p>
+          <span>- Client A</span>
+        </div>
+        <div class="testimonial-card">
+          <p>"Professional, reliable, and highly skilled."</p>
+          <span>- Client B</span>
+        </div>
+        <div class="testimonial-card">
+          <p>"Great communication and attention to detail throughout the project."</p>
+          <span>- Client C</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="cta fade-in">
+    <div class="container">
+      <h2>Ready to start a project?</h2>
+      <p>Let's build something great together.</p>
+      <a href="#contact" class="btn cta-btn">Get in Touch</a>
     </div>
   </section>
 
@@ -60,11 +147,20 @@
     </div>
   </section>
 
+  </main>
+
   <footer>
     <div class="container">
       <p>&copy; 2025 Daniel Tibbotts</p>
     </div>
   </footer>
+  <div id="modal" class="modal" aria-hidden="true">
+    <div class="modal-content" role="dialog" aria-modal="true">
+      <button class="modal-close" aria-label="Close">&times;</button>
+      <img src="" alt="" class="modal-img">
+      <div class="modal-body"></div>
+    </div>
+  </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,9 +1,76 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', () => {
   const toggle = document.querySelector('.nav-toggle');
   const nav = document.querySelector('header nav');
   if (toggle && nav) {
-    toggle.addEventListener('click', function() {
+    toggle.addEventListener('click', () => {
       nav.classList.toggle('show');
     });
   }
+
+  const sections = document.querySelectorAll('section[id]');
+  const navLinks = document.querySelectorAll('header nav a');
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      const id = entry.target.getAttribute('id');
+      const link = document.querySelector(`header nav a[href="#${id}"]`);
+      if (entry.isIntersecting) {
+        navLinks.forEach(l => l.classList.remove('active'));
+        if (link) link.classList.add('active');
+        entry.target.classList.add('visible');
+      }
+    });
+  }, { threshold: 0.6 });
+
+  sections.forEach(section => {
+    observer.observe(section);
+  });
+
+  const filterButtons = document.querySelectorAll('.filter-btn');
+  const projects = document.querySelectorAll('.project-item');
+
+  filterButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      filterButtons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      const filter = btn.dataset.filter;
+      projects.forEach(p => {
+        if (filter === 'all' || p.dataset.category === filter) {
+          p.classList.remove('hidden');
+        } else {
+          p.classList.add('hidden');
+        }
+      });
+    });
+  });
+
+  const modal = document.getElementById('modal');
+  const modalImg = modal.querySelector('.modal-img');
+  const modalBody = modal.querySelector('.modal-body');
+  const closeBtn = modal.querySelector('.modal-close');
+  let lastFocus;
+
+  document.querySelectorAll('.project-item').forEach(item => {
+    item.addEventListener('click', () => {
+      lastFocus = document.activeElement;
+      modalImg.src = item.querySelector('img').src;
+      modalBody.textContent = item.dataset.description || '';
+      modal.classList.add('show');
+      modal.setAttribute('aria-hidden', 'false');
+      closeBtn.focus();
+    });
+  });
+
+  function closeModal() {
+    modal.classList.remove('show');
+    modal.setAttribute('aria-hidden', 'true');
+    if (lastFocus) lastFocus.focus();
+  }
+
+  closeBtn.addEventListener('click', closeModal);
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && modal.classList.contains('show')) {
+      closeModal();
+    }
+  });
 });

--- a/style.css
+++ b/style.css
@@ -1,14 +1,23 @@
+html {
+  scroll-behavior: smooth;
+}
+
+:root {
+  --accent: #17b8d9;
+}
+
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', Arial, sans-serif;
   margin: 0;
   padding: 0;
-  background: #fff;
-  color: #333;
+  background: #111;
+  color: #eee;
+  line-height: 1.6;
   padding-top: 60px;
 }
 
 header {
-  background: #003d5b;
+  background: #000;
   color: #fff;
   position: fixed;
   top: 0;
@@ -22,6 +31,17 @@ header .container {
   justify-content: space-between;
   align-items: center;
   padding: 1em;
+}
+
+header nav a {
+  color: #fff;
+  margin-left: 1em;
+  text-decoration: none;
+  position: relative;
+}
+
+header nav a.active {
+  color: var(--accent);
 }
 
 .nav-toggle {
@@ -41,14 +61,8 @@ header .container {
   background: #fff;
 }
 
-header nav a {
-  color: #fff;
-  margin-left: 1em;
-  text-decoration: none;
-}
-
 .hero {
-  background: linear-gradient(135deg, #01796f, #38a2d7);
+  background: #222;
   color: #fff;
   padding: 6em 0;
   text-align: center;
@@ -72,33 +86,62 @@ header nav a {
   margin: 0.2em 0;
 }
 
-.hero-text p {
-  font-size: 1.2em;
-}
-
 .btn {
   display: inline-block;
   margin-top: 1em;
   padding: 0.75em 1.5em;
-  background: #fff;
-  color: #01796f;
+  background: var(--accent);
+  color: #000;
   text-decoration: none;
   border-radius: 4px;
   font-weight: bold;
 }
 
 .btn:hover {
-  background: #f4f4f4;
+  opacity: 0.8;
 }
 
-.about, .projects, .contact {
-  padding: 2em 0;
+section {
+  padding: 3em 0;
 }
 
 .container {
   width: 90%;
   max-width: 1200px;
   margin: 0 auto;
+}
+
+.why {
+  background: #1a1a1a;
+  color: #ddd;
+}
+
+.why blockquote {
+  margin: 1.5em 0 0;
+  padding-left: 1em;
+  border-left: 4px solid var(--accent);
+  color: #ccc;
+  font-style: italic;
+}
+
+.filter-bar {
+  text-align: center;
+  margin-bottom: 1em;
+}
+
+.filter-btn {
+  background: #333;
+  color: #eee;
+  border: none;
+  padding: 0.5em 1em;
+  margin: 0.25em;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.filter-btn.active {
+  background: var(--accent);
+  color: #000;
 }
 
 .project-grid {
@@ -108,33 +151,134 @@ header nav a {
 }
 
 .project-item {
-  flex: 1 1 calc(33% - 1em);
-  background: #f4f4f4;
-  padding: 1em;
-  box-sizing: border-box;
-  transition: background 0.3s;
+  position: relative;
+  flex: 1 1 calc(33.333% - 1em);
+  border-radius: 8px;
+  overflow: hidden;
   cursor: pointer;
 }
 
-.project-item:hover {
-  background: #e0e0e0;
+.project-item img {
+  width: 100%;
+  display: block;
+}
+
+.project-item .overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.project-item:hover .overlay {
+  opacity: 1;
+}
+
+.hidden {
+  display: none;
+}
+
+.testimonial-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+}
+
+.testimonial-card {
+  background: #222;
+  padding: 1em;
+  border-radius: 8px;
+  flex: 1 1 calc(33.333% - 1em);
+}
+
+.cta {
+  background: #333;
+  text-align: center;
+}
+
+.cta-btn {
+  background: var(--accent);
+  color: #000;
+}
+
+.contact {
+  text-align: center;
 }
 
 footer {
-  background: #333;
+  background: #000;
   color: #fff;
   text-align: center;
   padding: 1em 0;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.modal.show {
+  display: flex;
+}
+
+.modal-content {
+  background: #fff;
+  color: #000;
+  max-width: 90%;
+  max-height: 90%;
+  overflow: auto;
+  border-radius: 8px;
+  position: relative;
+  padding: 1em;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.5em;
+  right: 0.5em;
+  background: none;
+  border: none;
+  font-size: 1.5em;
+  cursor: pointer;
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.fade-in.visible {
+  opacity: 1;
+  transform: none;
 }
 
 @media (max-width: 900px) {
   .project-item {
     flex-basis: calc(50% - 1em);
   }
+
+  .testimonial-card {
+    flex-basis: calc(50% - 1em);
+  }
 }
 
 @media (max-width: 600px) {
   .project-item {
+    flex-basis: 100%;
+  }
+
+  .testimonial-card {
     flex-basis: 100%;
   }
 
@@ -146,7 +290,7 @@ footer {
     display: none;
     flex-direction: column;
     width: 100%;
-    background: #003d5b;
+    background: #000;
   }
 
   header nav.show {


### PR DESCRIPTION
## Summary
- redesign index into a single page portfolio layout
- implement filtering, modal popups, testimonials and CTA
- add intersection observer scroll effects and active nav highlighting
- update styles with dark theme and overlay effects

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686437f634548324b842d7f913b6bea1